### PR TITLE
Reimplented core tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
 		</dependency>
@@ -50,11 +54,16 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
-		<!--<dependency>
+		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
 			<version>2.0.1.Final</version>
-		</dependency>-->
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.8.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springdoc</groupId>
@@ -65,6 +74,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/model/User.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/model/User.java
@@ -36,7 +36,7 @@ public class User {
     /**
      * Constructor
      */
-    public User(String username, String email, String password, String firstName, String lastName, String address) {
+    public User(String username, String password, String email, String firstName, String lastName, String address) {
         this.username = username;
         this.email = email;
         this.password = password;

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/model/User.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/model/User.java
@@ -30,9 +30,6 @@ public class User {
     @DBRef
     private Set<Role> roles = new HashSet<>();
 
-    public User() {
-    }
-
     /**
      * Constructor
      */

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/WebSecurityConfig.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/WebSecurityConfig.java
@@ -94,6 +94,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/swagger-ui.html").permitAll()
                 .antMatchers("/").permitAll()
                 .antMatchers("/index.html").permitAll()
+                .antMatchers("/login").permitAll()
                 .antMatchers("/actuator/**").permitAll()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated();

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/jwt/JwtUtils.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/jwt/JwtUtils.java
@@ -36,6 +36,10 @@ public class JwtUtils {
     public String generateJwtToken(Authentication authentication) {
 
         //Creates a User Detail object with our custom authentications
+        System.out.println(authentication);
+        System.out.println(authentication.getPrincipal());
+        System.out.println(authentication.getCredentials());
+        System.out.println(authentication.getDetails());
         UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
 
         //Build JWT

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/jwt/JwtUtils.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/security/jwt/JwtUtils.java
@@ -31,15 +31,16 @@ public class JwtUtils {
      * Creates the JWT
      *
      * @param authentication User's authentications
+     * @throws IllegalArgumentException If the authentication hasn't been completed and "Authenticated" is false
      * @return built JWT
      */
-    public String generateJwtToken(Authentication authentication) {
+    public String generateJwtToken(Authentication authentication) throws IllegalArgumentException {
+
+        if (!authentication.isAuthenticated()) {
+            throw new IllegalArgumentException("Authentication object provided is not completed -- auth required");
+        }
 
         //Creates a User Detail object with our custom authentications
-        System.out.println(authentication);
-        System.out.println(authentication.getPrincipal());
-        System.out.println(authentication.getCredentials());
-        System.out.println(authentication.getDetails());
         UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
 
         //Build JWT

--- a/src/main/java/com/cmplxsoftsys/team3/financeapplication/service/AuthServiceImpl.java
+++ b/src/main/java/com/cmplxsoftsys/team3/financeapplication/service/AuthServiceImpl.java
@@ -47,8 +47,8 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public ResponseEntity<?> authenticateUser(@Valid LoginRequest loginRequest) {
         Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
-
+            new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword())
+        );
         SecurityContextHolder.getContext().setAuthentication(authentication);
         String jwt = jwtUtils.generateJwtToken(authentication);
 
@@ -79,9 +79,14 @@ public class AuthServiceImpl implements AuthService {
         }
 
         // Create new user's account
-        User user = new User(signUpRequest.getUsername(),
+        User user = new User(
+                signUpRequest.getUsername(),
+                encoder.encode(signUpRequest.getPassword()),
                 signUpRequest.getEmail(),
-                encoder.encode(signUpRequest.getPassword()), signUpRequest.getFirstName(), signUpRequest.getLastName(), signUpRequest.getAddress());
+                signUpRequest.getFirstName(),
+                signUpRequest.getLastName(),
+                signUpRequest.getAddress()
+            );
 
         Set<String> strRoles = signUpRequest.getRoles();
         Set<Role> roles = new HashSet<>();

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/FinanceapplicationApplicationTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/FinanceapplicationApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class FinanceapplicationApplicationTests {
 
-	//@Test
-	//void contextLoads() {
-	//}
+	@Test
+	void contextLoads() {
+	}
 
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/FinanceapplicationApplicationTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/FinanceapplicationApplicationTests.java
@@ -1,13 +1,22 @@
 package com.cmplxsoftsys.team3.financeapplication;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class FinanceapplicationApplicationTests {
 
+	@Autowired
+    private WebApplicationContext context;
+
+	
 	@Test
 	void contextLoads() {
+		assertThat(context).isNotNull();
 	}
-
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/AuthenticationTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/AuthenticationTests.java
@@ -1,6 +1,104 @@
 package com.cmplxsoftsys.team3.financeapplication.controllertests;
 
+import com.cmplxsoftsys.team3.financeapplication.controller.AuthController;
+import com.cmplxsoftsys.team3.financeapplication.model.User;
+import com.cmplxsoftsys.team3.financeapplication.security.service.UserDetailsImpl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import org.mockito.Mockito;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 public class AuthenticationTests {
+
+    @Autowired
+    private AuthController controller;
+
+    @Autowired
+    private PasswordEncoder encoder;
+
+    // for making sure we can communicate with how server is configured
+    @LocalServerPort
+	private int port;
+    
+    @Autowired
+    private WebApplicationContext context;
+
+    // for mocking and testing
+    private MockMvc mvc;
+    
+    @Autowired
+    AuthenticationManager authenticationManager;
+
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+          .webAppContextSetup(context)
+          .apply(SecurityMockMvcConfigurers.springSecurity())
+          .build();
+    }
+
+    @Test
+    public void contextLoads() throws Exception {
+        assertThat(controller).isNotNull();
+    }
+
+    @Test
+    public void successfullyPerformLogin_UsingCreds() throws Exception {
+        String endpoint = "/api/auth/signin";
+
+        String testUsername = "testuser";
+        String testPassword = "testpass";
+        String encodedPassword = encoder.encode(testPassword);
+
+
+        String payload = String.format("{\"username\": \"%s\", \"password\": \"%s\"}", testUsername, testPassword);
+
+        Authentication fakeAuth = new UsernamePasswordAuthenticationToken(testUsername, testPassword);
+        Authentication spyAuth = Mockito.spy(fakeAuth);
+        User mockUser = new User(testUsername, encodedPassword, "test@example.com", "testFirstname", "testLastname", "123 fake street, fake town, NA 12345");
+        UserDetailsImpl mockPrincipal = UserDetailsImpl.build(mockUser);
+
+
+        // Mock user auth so it always thinks the password is the same as testPassword
+        AuthenticationManager spyAuthManager = Mockito.spy(authenticationManager);
+        Mockito.when(spyAuthManager.authenticate(Mockito.any())).thenReturn(spyAuth);
+        Mockito.when(spyAuth.getPrincipal()).thenReturn(mockPrincipal);
+
+        this.mvc.perform(
+            post(endpoint)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload)
+        ).andExpect(status().isOk())
+        .andDo(print());
+    }
+
+    
     
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/LoanUseCaseTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/LoanUseCaseTests.java
@@ -1,0 +1,90 @@
+package com.cmplxsoftsys.team3.financeapplication.controllertests;
+
+import com.cmplxsoftsys.team3.financeapplication.controller.LoanController;
+import com.cmplxsoftsys.team3.financeapplication.repository.LoanApplicationRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class LoanUseCaseTests {
+
+    @Autowired
+    private LoanController controller;
+    
+    @Autowired
+    private WebApplicationContext context;
+
+    // for mocking and testing
+    private MockMvc mvc;
+
+    @MockBean
+    private LoanApplicationRepository repository;
+
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+          .webAppContextSetup(context)
+          .apply(SecurityMockMvcConfigurers.springSecurity())
+          .build();
+    }
+
+    
+    @Test
+    public void contextLoads() throws Exception {
+        assertThat(controller).isNotNull();
+    }
+
+
+    @Test
+    public void unauthenticatedUserSubmitsLoanRequest_ReturnsUnauthorized() throws Exception {
+        String endpoint = "/api/loan/request";
+
+        this.mvc.perform(
+            post(endpoint)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isUnauthorized());
+    }
+
+
+    @WithMockUser("moderator")
+    @Test
+    public void authenticatedUserSubmitsLoanRequest_RequestIsSuccessful() throws Exception {
+        String endpoint = "/api/loan/request";
+
+        double loanAmount = 9999.99;
+        String userId = "testrequester";
+        String loanType = "testReqType";
+        
+        String payload = String.format("{\"userId\": \"%s\", \"type\": \"%s\", \"loanAmount\": %f}", userId, loanType, loanAmount);
+        
+        // since the repo is mocked, it won't actually write here
+        this.mvc.perform(
+            post(endpoint)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload)
+        ).andExpect(status().isOk());
+
+        // verify the data would have been written to DB if it wasn't mocked
+        Mockito.verify(repository).save(Mockito.any());
+    }
+}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/RestControllerTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/RestControllerTests.java
@@ -1,5 +1,0 @@
-package com.cmplxsoftsys.team3.financeapplication.controllertests;
-
-public class RestControllerTests {
-    
-}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/UiControllerTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/UiControllerTests.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -23,20 +22,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class UiControllerTests {
     @Autowired
     private UiController controller;
-
-    // for making sure we can communicate with how server is configured
-    @LocalServerPort
-	private int port;
     
     @Autowired
     private WebApplicationContext context;
 
     private MockMvc mvc;
 
+    
     @BeforeEach
     public void setup() {
         this.mvc = MockMvcBuilders
@@ -44,6 +40,7 @@ public class UiControllerTests {
           .apply(SecurityMockMvcConfigurers.springSecurity())
           .build();
     }
+
 
     /**
      * This function tests that the controller can be instantiated correctly.
@@ -54,11 +51,13 @@ public class UiControllerTests {
         assertThat(controller).isNotNull();
     }
 
+
     @Test
     public void indexRequestReturnsOk_NoAuthReq() throws Exception {
         String endpoint = "/";
         mvc.perform(get(endpoint)).andExpect(status().isOk());
     }
+
 
     @Test
     public void loginPageReqestReturnsValid_NoAuthReq() throws Exception {
@@ -66,11 +65,13 @@ public class UiControllerTests {
         mvc.perform(get(endpoint)).andExpect(status().isOk());
     }
 
+
     @Test
     public void accountDashboardRequestFails_Unauthorized_NoAuth() throws Exception {
         String endpoint = "/account";
         mvc.perform(get(endpoint)).andExpect(status().is4xxClientError());
     }
+
 
     @WithMockUser("moderator")
     @Test

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/UiControllerTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/controllertests/UiControllerTests.java
@@ -1,31 +1,81 @@
 package com.cmplxsoftsys.team3.financeapplication.controllertests;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.cmplxsoftsys.team3.financeapplication.controller.UiController;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-@SpringBootTest
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 public class UiControllerTests {
-    //@Autowired
-    //private UiController controller;
+    @Autowired
+    private UiController controller;
+
+    // for making sure we can communicate with how server is configured
+    @LocalServerPort
+	private int port;
+    
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    public void setup() {
+        this.mvc = MockMvcBuilders
+          .webAppContextSetup(context)
+          .apply(SecurityMockMvcConfigurers.springSecurity())
+          .build();
+    }
 
     /**
      * This function tests that the controller can be instantiated correctly.
      * @throws Exception
      */
-    //@Test
-    //public void contextLoads() throws Exception {
-    //    assertThat(controller).isNotNull();
-    //}
+    @Test
+    public void contextLoads() throws Exception {
+        assertThat(controller).isNotNull();
+    }
 
-    
-    //@Test
-    //public void validReturn() {
-    //    assertEquals("index", controller.getHomepage());
-    //}
+    @Test
+    public void indexRequestReturnsOk_NoAuthReq() throws Exception {
+        String endpoint = "/";
+        mvc.perform(get(endpoint)).andExpect(status().isOk());
+    }
+
+    @Test
+    public void loginPageReqestReturnsValid_NoAuthReq() throws Exception {
+        String endpoint = "/login";
+        mvc.perform(get(endpoint)).andExpect(status().isOk());
+    }
+
+    @Test
+    public void accountDashboardRequestFails_Unauthorized_NoAuth() throws Exception {
+        String endpoint = "/account";
+        mvc.perform(get(endpoint)).andExpect(status().is4xxClientError());
+    }
+
+    @WithMockUser("moderator")
+    @Test
+    public void accountDashboardRequestSucceeds_Authorized_MockingUser() throws Exception {
+        String endpoint = "/account";
+        mvc.perform(get(endpoint)).andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/LoanApplicationTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/LoanApplicationTests.java
@@ -1,0 +1,30 @@
+package com.cmplxsoftsys.team3.financeapplication.modeltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cmplxsoftsys.team3.financeapplication.model.LoanApplication;
+
+import org.junit.jupiter.api.Test;
+
+public class LoanApplicationTests {
+
+    private String type = "testtype";
+    private double amount = 12345.67;
+    private String userId = "testid";
+
+    
+    @Test
+    public void objectCanBeInstantiated() {
+        LoanApplication testInstance = new LoanApplication(type, amount, userId);
+        assertThat(testInstance).isNotNull();
+    }
+
+
+    @Test
+    public void instanceCorrectlyReturnsAttributeValuesWithGets() throws Exception {
+        LoanApplication testInstance = new LoanApplication(type, amount, userId);
+        assertThat(testInstance.getType()).isEqualTo(type);
+        assertThat(testInstance.getAmount()).isEqualTo(amount);
+        assertThat(testInstance.getUserId()).isEqualTo(userId);
+    }
+}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/LoanTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/LoanTests.java
@@ -1,5 +1,48 @@
 package com.cmplxsoftsys.team3.financeapplication.modeltests;
 
+import com.cmplxsoftsys.team3.financeapplication.model.Loan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
 public class LoanTests {
+
+    private double annualInterestRate = 1.99;
+    private int numberOfYears = 5;
+    private double loanAmount = 12345.67;
+    private String loanType = "testtype";
+
     
+    @Test
+    public void loanCanBeInstantiated() {
+        Loan testLoan = new Loan(annualInterestRate, numberOfYears, loanAmount, loanType);
+        assertThat(testLoan).isNotNull();
+    }
+
+
+    @Test
+    public void loanCorrectlyReturnsFieldValues() {
+        Loan testLoan = new Loan(annualInterestRate, numberOfYears, loanAmount, loanType);
+
+        assertThat(testLoan.getAnnualInterestRate()).isEqualTo(annualInterestRate);
+        assertThat(testLoan.getNumberOfYears()).isEqualTo(numberOfYears);
+        assertThat(testLoan.getLoanAmount()).isEqualTo(loanAmount);
+        assertThat(testLoan.getLoanType()).isEqualTo(loanType);
+    }
+
+
+    @Test
+    public void loanAttributesCanSuccessfullyBeChanged() {
+        Loan testLoan = new Loan(annualInterestRate, numberOfYears, loanAmount, loanType);
+
+        testLoan.setAnnualInterestRate(99999);
+        assertThat(testLoan.getAnnualInterestRate()).isNotEqualTo(annualInterestRate);
+        testLoan.setNumberOfYears(99999);
+        assertThat(testLoan.getNumberOfYears()).isNotEqualTo(numberOfYears);
+        testLoan.setLoanAmount(99999);
+        assertThat(testLoan.getLoanAmount()).isNotEqualTo(loanAmount);
+        testLoan.setLoanType("something different");
+        assertThat(testLoan.getLoanType()).isNotEqualTo(loanType);
+    }
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/RoleTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/RoleTests.java
@@ -1,5 +1,35 @@
 package com.cmplxsoftsys.team3.financeapplication.modeltests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cmplxsoftsys.team3.financeapplication.model.ERole;
+import com.cmplxsoftsys.team3.financeapplication.model.Role;
+
+import org.junit.jupiter.api.Test;
+
 public class RoleTests {
+
+    private ERole testRole = ERole.ROLE_MODERATOR;
     
+    
+    @Test
+    public void objectCanBeInstantiated() {
+        Role testInstance = new Role(testRole);
+        assertThat(testInstance).isNotNull();
+    }
+
+
+    @Test
+    public void roleAttributesCanCorrectlyBeRetrievedViaGets() throws Exception {
+        Role testInstance = new Role(testRole);
+        assertThat(testInstance.getName()).isEqualTo(testRole);
+    }
+ 
+    
+    @Test
+    public void roleAttributesCanCorrectlyBeChangedViaSets() throws Exception {
+        Role testInstance = new Role(testRole);
+        testInstance.setName(ERole.ROLE_USER);
+        assertThat(testInstance.getName()).isNotEqualTo(testRole);
+    }
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/UserTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/modeltests/UserTests.java
@@ -1,5 +1,56 @@
 package com.cmplxsoftsys.team3.financeapplication.modeltests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cmplxsoftsys.team3.financeapplication.model.User;
+
+import org.junit.jupiter.api.Test;
+
 public class UserTests {
     
+    private String username = "tester";
+    private String password = "fakepass";
+    private String email = "fakemail@test.example.com";
+    private String firstName = "Tommy";
+    private String lastName = "Tester";
+    private String address = "123 Fake Street, Gotham, NY 10001";
+
+
+    @Test
+    public void objectCanBeInstantiated() {
+        User testInstance = new User(username, password, email, firstName, lastName, address);
+        assertThat(testInstance).isNotNull();
+    }
+
+
+    @Test
+    public void userObjectCorrectlyReturnsFieldValues() {
+        User testInstance = new User(username, password, email, firstName, lastName, address);
+
+        assertThat(testInstance.getUsername()).isEqualTo(username);
+        assertThat(testInstance.getPassword()).isEqualTo(password);
+        assertThat(testInstance.getEmail()).isEqualTo(email);
+        assertThat(testInstance.getFirstName()).isEqualTo(firstName);
+        assertThat(testInstance.getLastName()).isEqualTo(lastName);
+        assertThat(testInstance.getAddress()).isEqualTo(address);
+    }
+
+    
+    @Test
+    public void userObjectAttributedCanSuccessfullyBeChangedViaSets() {
+        User testInstance = new User(username, password, email, firstName, lastName, address);
+
+        testInstance.setUsername("newusername");
+        assertThat(testInstance.getUsername()).isNotEqualTo(username);
+        testInstance.setPassword("newpassword");
+        assertThat(testInstance.getPassword()).isNotEqualTo(password);
+        testInstance.setEmail("newemail@example.com");
+        assertThat(testInstance.getEmail()).isNotEqualTo(email);
+        testInstance.setFirstName("newFirst");
+        assertThat(testInstance.getFirstName()).isNotEqualTo(firstName);
+        testInstance.setLastName("newLast");
+        assertThat(testInstance.getLastName()).isNotEqualTo(lastName);
+        testInstance.setAddress("newStreet");
+        assertThat(testInstance.getAddress()).isNotEqualTo(address);
+    }
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/LoanTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/LoanTests.java
@@ -1,5 +1,0 @@
-package com.cmplxsoftsys.team3.financeapplication.payloadtests;
-
-public class LoanTests {
-    
-}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/LoginTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/LoginTests.java
@@ -1,5 +1,0 @@
-package com.cmplxsoftsys.team3.financeapplication.payloadtests;
-
-public class LoginTests {
-    
-}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/SignupTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/payloadtests/SignupTests.java
@@ -1,5 +1,0 @@
-package com.cmplxsoftsys.team3.financeapplication.payloadtests;
-
-public class SignupTests {
-    
-}

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/securitytests/JwtTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/securitytests/JwtTests.java
@@ -1,5 +1,92 @@
 package com.cmplxsoftsys.team3.financeapplication.securitytests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+
+import com.cmplxsoftsys.team3.financeapplication.model.User;
+import com.cmplxsoftsys.team3.financeapplication.repository.UserRepository;
+import com.cmplxsoftsys.team3.financeapplication.security.jwt.JwtUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class JwtTests {
+
+    @Autowired
+    PasswordEncoder encoder;
+
+    @Autowired
+    AuthenticationManager authManager;
+
+    @MockBean
+    UserRepository repository;
+
+    @Autowired
+    JwtUtils jwtUtils;
+
     
+    @Test
+    public void forValidAuthenticationJWTIsSuccessfullyGenerated() throws Exception {
+        String testUsername = "testUser";
+        String testPassword = "testPassword";
+        
+        User fakeUser = new User(testUsername, encoder.encode(testPassword), "tester@example.com", "Tommy", "Tester", "fake street");
+        Optional<User> fakeRepoReturn = Optional.of(fakeUser);
+        Mockito.when(repository.findByUsername(testUsername)).thenReturn(fakeRepoReturn);
+
+        Authentication auth = authManager.authenticate(new UsernamePasswordAuthenticationToken(testUsername, testPassword));
+
+        String jwt = jwtUtils.generateJwtToken(auth);
+        System.out.println(jwt);
+        assertThat(jwt).isNotNull();
+    }
+
+
+    @Test
+    public void forBadAuthenticationJWTIsNotGenerated_ThrowsInvalidArgumentException() throws Exception {
+        String testUsername = "nonexistant";
+        String testPassword = "doesnt matter";
+
+        Authentication badAuth = new UsernamePasswordAuthenticationToken(testUsername, testPassword);
+        assertThrows(IllegalArgumentException.class, () -> {jwtUtils.generateJwtToken(badAuth);});
+    }
+
+
+    @Test
+    public void usernameCanBeParsedFromCorrectlyFormattedJWT() throws Exception {
+        String testUsername = "testUser";
+        String testJWT = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0VXNlciIsImlhdCI6MTYxNDg3ODE5OCwiZXhwIjoxNjE0OTY0NTk4fQ.1-z4_u5uJ-KdrutUV0pB_86LjUTZTTxY86BFe7UTVD4ZAQjWCWZLBK-kaNJ5sUqwuBppOD9tXreQ561FtbCICQ";
+        String result = jwtUtils.getUserNameFromJwtToken(testJWT);
+        assertThat(result).isEqualTo(testUsername);
+    }
+
+    
+    @Test
+    public void correctlyFormattedJWTIsSuccessfullyValidated() throws Exception {
+        String testJWT = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0VXNlciIsImlhdCI6MTYxNDg3ODE5OCwiZXhwIjoxNjE0OTY0NTk4fQ.1-z4_u5uJ-KdrutUV0pB_86LjUTZTTxY86BFe7UTVD4ZAQjWCWZLBK-kaNJ5sUqwuBppOD9tXreQ561FtbCICQ";
+        boolean valid = jwtUtils.validateJwtToken(testJWT);
+        assertThat(valid).isTrue();
+    }
+
+
+    @Test
+    public void invalidFormattedJWTCorrectlyFailsValidation() throws Exception {
+        String testJWT = "testing.this.isnt.a.jwt";
+        boolean valid = jwtUtils.validateJwtToken(testJWT);
+        assertThat(valid).isFalse();
+    }
 }

--- a/src/test/java/com/cmplxsoftsys/team3/financeapplication/servicetests/LoanServiceTests.java
+++ b/src/test/java/com/cmplxsoftsys/team3/financeapplication/servicetests/LoanServiceTests.java
@@ -1,0 +1,91 @@
+package com.cmplxsoftsys.team3.financeapplication.servicetests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cmplxsoftsys.team3.financeapplication.model.LoanApplication;
+import com.cmplxsoftsys.team3.financeapplication.payload.request.LoanApplicationRequest;
+import com.cmplxsoftsys.team3.financeapplication.repository.LoanApplicationRepository;
+import com.cmplxsoftsys.team3.financeapplication.service.LoanApplicationServiceImpl;
+import com.cmplxsoftsys.team3.financeapplication.service.LoanServiceImpl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class LoanServiceTests {
+
+    @Autowired
+    LoanApplicationServiceImpl loanApplicationService;
+
+    @Autowired
+    LoanServiceImpl loanService;
+
+    @MockBean
+    LoanApplicationRepository repository;
+
+
+    @Test
+    public void contextLoads() throws Exception {
+        assertThat(repository).isNotNull();
+    }
+
+
+    @Test
+    public void validLoanApplicationIsSuccessfullyProcessedIfSubmitted() throws Exception {
+
+        LoanApplication fakeApplication = new LoanApplication("testtype", 12345.67, "testid");
+
+        LoanApplicationRequest loanAppRequest = Mockito.mock(LoanApplicationRequest.class);
+        Mockito.when(loanAppRequest.getUserId()).thenReturn(fakeApplication.getUserId());
+        Mockito.when(loanAppRequest.getType()).thenReturn(fakeApplication.getType());
+        Mockito.when(loanAppRequest.getLoanAmount()).thenReturn(fakeApplication.getAmount());
+
+        loanApplicationService.submitLoanApplication(loanAppRequest);
+        // verify that save was called once (e.g. it would have been a write)
+        Mockito.verify(repository).save(Mockito.any());
+    }
+
+
+    //TODO replace test stubs once the classes are implemented
+
+    @Test
+    public void validLoanContentsIsCorrectlyValidated() throws Exception {
+        Object results = loanService.verifyLoanContents();
+        assertThat(results).isNull();  // for now until stub is written
+    }
+
+
+    @Test
+    public void validateUSDConversionIsCalculatedCorrectly() throws Exception {
+        Object results = loanService.convertToUSD();
+        assertThat(results).isNull();  // for now until stub is written
+    }
+
+
+    @Test
+    public void validateLoanApplicationCanBeSubmitted_LoanWouldWriteToDB() throws Exception {
+        Object results = loanService.submitLoanApplication();
+        assertThat(results).isNull();  // for now until stub is written
+    }
+
+
+    @Test
+    public void loanServiceReturnsLoanDetailsForGivenAccount() throws Exception {
+        Object results = loanService.getLoansForAccount();
+        assertThat(results).isNull();  // for now until stub is written
+    }
+
+    
+    @Test
+    public void userCanCheckLoanApplicationStatusSuccessfully() throws Exception {
+        Object results = loanService.getLoanApplicationStatus();
+        assertThat(results).isNull();  // for now until stub is written
+    }
+}


### PR DESCRIPTION
This is just the tests and all are passing in my testing.

I also made the following QA changes:
- User not does not have a blank constructor which should prevent invalid objects from being instantiated
- JwtUtil's generateJwtToken now will not generate a token for an invalid authorization. Previously it would throw an uncaught exception and cause unintended behavior.